### PR TITLE
Added running mode configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,12 @@ An example of the content of the JSON persistence file.
 ## Config
 To the existing configuration in the SequenceSender section from the Node, the following new configuration parameters have been added:
 
+The running mode of the sequence sender:
+```
+[SequenceSender]
+Mode="validium" # or "rollup"
+```
+
 Maximum number of transactions pending completion. Once this number is reached, no new transactions will be sent until one completes (that reaches the `consolidated` state):
 ```
 [SequenceSender]

--- a/config/default.go
+++ b/config/default.go
@@ -11,6 +11,7 @@ Level = "info"
 Outputs = ["stderr"]
 
 [SequenceSender]
+Mode = "rollup"
 WaitPeriodSendSequence = "15s"
 LastBatchVirtualizationTimeMaxWaitPeriod = "10s"
 MaxTxSizeForL1 = 131072

--- a/config/environments/local/app.config.toml
+++ b/config/environments/local/app.config.toml
@@ -4,6 +4,7 @@ Level = "info"
 Outputs = ["stderr"]
 
 [SequenceSender]
+Mode = "rollup"
 WaitPeriodSendSequence = "15s"
 LastBatchVirtualizationTimeMaxWaitPeriod = "10s"
 MaxTxSizeForL1 = 131072

--- a/dataavailability/dataavailability.go
+++ b/dataavailability/dataavailability.go
@@ -9,17 +9,12 @@ import (
 // DataAvailability implements an abstract data availability integration
 type DataAvailability struct {
 	backend DABackender
-
-	ctx context.Context
 }
 
 // New creates a DataAvailability instance
-func New(
-	backend DABackender,
-) (*DataAvailability, error) {
+func New(backend DABackender) (*DataAvailability, error) {
 	da := &DataAvailability{
 		backend: backend,
-		ctx:     context.Background(),
 	}
 	err := da.backend.Init()
 	return da, err

--- a/etherman/config.go
+++ b/etherman/config.go
@@ -6,6 +6,9 @@ import "github.com/0xPolygonHermez/zkevm-ethtx-manager/etherman"
 type Config struct {
 	EthermanConfig etherman.Config
 
+	// IsValidiumMode is a flag to indicate if the sequence sender is running in validium mode
+	IsValidiumMode bool
+
 	// ForkIDChunkSize is the max interval for each call to L1 provider to get the forkIDs
 	ForkIDChunkSize uint64 `mapstructure:"ForkIDChunkSize"`
 }

--- a/sequencesender/config.go
+++ b/sequencesender/config.go
@@ -9,6 +9,8 @@ import (
 
 // Config represents the configuration of a sequence sender
 type Config struct {
+	// Mode is the mode of the sequence sender. It can be either "validium" or "rollup".
+	Mode string `mapstructure:"Mode"`
 	// WaitPeriodSendSequence is the time the sequencer waits until
 	// trying to send a sequence to L1
 	WaitPeriodSendSequence types.Duration `mapstructure:"WaitPeriodSendSequence"`
@@ -61,6 +63,11 @@ type Config struct {
 
 	// MaxBatchesForL1 is the maximum amount of batches to be sequenced in a single L1 tx
 	MaxBatchesForL1 uint64 `mapstructure:"MaxBatchesForL1"`
+}
+
+// IsValidiumMode returns true if the mode is "validium"
+func (c *Config) IsValidiumMode() bool {
+	return c.Mode == "validium"
 }
 
 // StreamClientCfg contains the data streamer's configuration properties

--- a/sequencesender/interfaces.go
+++ b/sequencesender/interfaces.go
@@ -5,11 +5,12 @@ import (
 
 	ethmanTypes "github.com/0xPolygonHermez/zkevm-sequence-sender/etherman/types"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
 )
 
 type ethermaner interface {
 	CurrentNonce(ctx context.Context, account common.Address) (uint64, error)
-	BuildSequenceBatchesTxData(sender common.Address, sequences []ethmanTypes.Sequence, maxSequenceTimestamp uint64, lastSequencedBatchNumber uint64, l2Coinbase common.Address, dataAvailabilityMessage []byte) (to *common.Address, data []byte, err error)
+	BuildSequenceBatchesTx(sender common.Address, sequences []ethmanTypes.Sequence, maxSequenceTimestamp uint64, lastSequencedBatchNumber uint64, l2Coinbase common.Address, dataAvailabilityMessage []byte) (*types.Transaction, error)
 	GetLatestBatchNumber() (uint64, error)
 }
 


### PR DESCRIPTION
SS can be operating in "rollup" or "validium" modes.

The difference is that the validium mode sends sequences to DA and has a configured batch size. The rollup mode has a "dynamic" batch size and does not use the DA-specific logic. 